### PR TITLE
Attempts to fix Puppeteer path requirements.

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ import { init as exportData } from './js/export-data.js';
 import { spawn } from 'node:child_process';
 import {  default as process } from 'node:process';
 
-const startupLink = join('file://', __dirname, './html/startup.html');
+const startupLink = `file://${resolve(__dirname, './html/startup.html')}`;
 
 let inProgress = false;
 async function startDataScraping(uName = username, scrapeGallery = true, scrapeComments = true, scrapeFavorites) {

--- a/js/gallery/gallery-tile.js
+++ b/js/gallery/gallery-tile.js
@@ -55,9 +55,17 @@ export default {
       return this.thumbnail_name && this.is_thumbnail_saved;
     },
     computedImgPath() {
-      if (this.thumbnail_name && this.is_thumbnail_saved)
-        return `${this.contentPath}\\${this.cleanAccountName}\\thumbnail\\${this.thumbnail_name}`;
-      return `${this.contentPath}\\${this.cleanAccountName}\\${this.content_name}`;
+      const base = this.contentPath;
+      // Debug
+      console.log('[Debug] Base URL: ' + base);
+      const account = this.cleanAccountName;
+      // Use forward slash to join the URL parts
+      if (this.thumbnail_name && this.is_thumbnail_saved) {
+        return `${base}/${account}/thumbnail/${this.thumbnail_name}`;
+      }
+      // Debug
+      console.log('[Debug] Content name: ' + this.content_name);
+      return `${base}/${account}/${this.content_name}`;
     },
     fileExtension() {
       const fileExtension = this.content_name.split('.').pop().toUpperCase();
@@ -91,6 +99,8 @@ export default {
     },
     loadSubmission() {
       this.$emit('loadSubmission', this.id);
+      // Debug
+      console.log('[Debug] Local URL: ' + this.computedImgPath);
     },
     searchUser() {
       this.$emit('searchUser', this.username);

--- a/js/view-gallery.js
+++ b/js/view-gallery.js
@@ -5,9 +5,10 @@ import { scrapeComments } from './scrape-data.js';
 import { downloadSpecificContent } from './download-content.js';
 import { handleLogin, username } from './login.js';
 import open from 'open';
+import { pathToFileURL } from 'url';
 
-const galleryLink = join('file://', __dirname, './html/gallery.html');
-const contentPath = resolve('file://', '../fa_gallery_downloader/downloaded_content' );
+const galleryLink = pathToFileURL(resolve(__dirname, './html/gallery.html')).href;
+const contentPath = pathToFileURL(resolve(__dirname, './fa_gallery_downloader/downloaded_content')).href;
 
 let page = null;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fa-gallery-downloader-dx",
-  "version": "2.5.6",
+  "version": "2.6.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "fa-gallery-downloader",
-      "version": "2.5.6",
+      "name": "fa-gallery-downloader-dx",
+      "version": "2.6.1",
       "license": "MIT",
       "dependencies": {
         "@puppeteer/browsers": "^2.2.3",
@@ -25,7 +25,7 @@
         "sqlite3": "^5.1.7"
       },
       "bin": {
-        "fa-gallery-downloader": "index.js"
+        "fa-gallery-downloader-dx": "index.js"
       },
       "devDependencies": {
         "@radically-straightforward/package": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fa-gallery-downloader-dx",
-  "version": "2.5.6",
+  "version": "2.6.1",
   "description": "Dead simple gallery download for FurAffinity",
   "main": "index.js",
   "type": "module",


### PR DESCRIPTION
Puppeteer seemingly changed how paths were handled in the new update. This wasn't caught in development, as old puppeteer packages were still installed in the development environment.

Ex. 
`join('file://', __dirname, './html/startup.html'); is now` ``file://${resolve(__dirname, './html/startup.html')}`;`

This should resolve the crashing in the latest PR.