### PR TITLE
Add experimental macOS build support for Github Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
   insiders-build:
     strategy:
       matrix:
-        os: [windows, ubuntu]
+        os: [windows, ubuntu, macos]
         include:
           - os: windows
             build: |
@@ -22,8 +22,13 @@ jobs:
           - os: ubuntu
             build: |
               npx package
-              mv ../FA-Gallery-Downloader-DX.tar.gz ./fa-gallery-downloader-dx-${{github.ref_name}}.tar.gz
-            artifact: fa-gallery-downloader-dx-${{github.ref_name}}.tar.gz
+              mv ../FA-Gallery-Downloader-DX.tar.gz ./fa-gallery-downloader-dx-${{github.ref_name}}-linux.tar.gz
+            artifact: fa-gallery-downloader-dx-${{github.ref_name}}-linux.tar.gz
+          - os: macos
+            build: |
+              npx package
+              mv ../FA-Gallery-Downloader-DX.tar.gz ./fa-gallery-downloader-dx-${{github.ref_name}}-macos.tar.gz
+            artifact: fa-gallery-downloader-dx-${{github.ref_name}}-macos.tar.gz
     runs-on: ${{matrix.os}}-latest
     steps:
       - uses: actions/checkout@main
@@ -48,7 +53,10 @@ jobs:
           name: fa-gallery-downloader-dx-${{github.ref_name}}.zip
       - uses: actions/download-artifact@main
         with:
-          name: fa-gallery-downloader-dx-${{github.ref_name}}.tar.gz
+          name: fa-gallery-downloader-dx-${{github.ref_name}}-linux.tar.gz
+      - uses: actions/download-artifact@main
+        with:
+          name: fa-gallery-downloader-dx-${{github.ref_name}}-macos.tar.gz
       - uses: actions/create-release@v1
         id: create-release
         env:
@@ -70,6 +78,14 @@ jobs:
           GITHUB_TOKEN: ${{secrets.MY_GITHUB_TOKEN}}
         with:
           upload_url: ${{steps.create-release.outputs.upload_url}}
-          asset_path: fa-gallery-downloader-dx-${{github.ref_name}}.tar.gz
-          asset_name: fa-gallery-downloader-dx-${{github.ref_name}}.tar.gz
+          asset_path: fa-gallery-downloader-dx-${{github.ref_name}}-linux.tar.gz
+          asset_name: fa-gallery-downloader-dx-${{github.ref_name}}-linux.tar.gz
+          asset_content_type: application/gzip
+      - uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{secrets.MY_GITHUB_TOKEN}}
+        with:
+          upload_url: ${{steps.create-release.outputs.upload_url}}
+          asset_path: fa-gallery-downloader-dx-${{github.ref_name}}-macos.tar.gz
+          asset_name: fa-gallery-downloader-dx-${{github.ref_name}}-macos.tar.gz
           asset_content_type: application/gzip

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,7 @@ on:
       - main
     tags-ignore:
       - v*
+  workflow_dispatch:
 
 name: Test Build
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
   insiders-build:
     strategy:
       matrix:
-        os: [windows, ubuntu]
+        os: [windows, ubuntu, macos]
         include:
           - os: windows
             build: |
@@ -23,8 +23,13 @@ jobs:
           - os: ubuntu
             build: |
               npx package
-              mv ../FA-Gallery-Downloader-DX.tar.gz ./fa-gallery-downloader-dx-${{github.ref_name}}.tar.gz
-            artifact: fa-gallery-downloader-dx-${{github.ref_name}}.tar.gz
+              mv ../FA-Gallery-Downloader-DX.tar.gz ./fa-gallery-downloader-dx-${{github.ref_name}}-linux.tar.gz
+            artifact: fa-gallery-downloader-dx-${{github.ref_name}}-linux.tar.gz
+          - os: macos
+            build: |
+              npx package
+              mv ../FA-Gallery-Downloader-DX.tar.gz ./fa-gallery-downloader-dx-${{github.ref_name}}-macos.tar.gz
+            artifact: fa-gallery-downloader-dx-${{github.ref_name}}-macos.tar.gz
     runs-on: ${{matrix.os}}-latest
     steps:
       - uses: actions/checkout@main


### PR DESCRIPTION
**CI/CD Workflow Enhancements:**

* Added macOS to the build matrix in both `main.yml` and `test.yml` workflows, so builds now run on Windows, Linux, and macOS runners. [[1]](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3L15-R15) [[2]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88R9-R17)
* For each OS, the packaged artifact is now named with its target platform (e.g., `fa-gallery-downloader-dx-<ref>-macos.tar.gz`), improving clarity and organization of build outputs. [[1]](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3L25-R31) [[2]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L26-R33)

**Release Process Improvements:**

* Updated the release workflow to upload both Linux and macOS artifacts to GitHub Releases, ensuring users can download platform-specific builds. [[1]](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3L51-R59) [[2]](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3L73-R90)

**Workflow Usability:**

* Enabled manual triggering of the test workflow via `workflow_dispatch`, allowing developers to run tests on demand.